### PR TITLE
fix(content): 优化用户名提取逻辑

### DIFF
--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -10,8 +10,8 @@ import { testIsV2EX } from '@/service/utils';
 export const detectAndGetInfo = (): PageInfo => {
   const isV2ex = testIsV2EX(window.location.hostname);
 
-  const memberLink = Array.from(document.querySelectorAll('a'))
-    .find(a => /^\/member\/[\w-]+$/.test(a.getAttribute('href') || ''));
+  const memberLink = Array.from(document.querySelectorAll('#Top a'))
+    .find(a => /^\/member\/[\w-]+$/.test(a.getAttribute('href') || '')) as HTMLAnchorElement | undefined;
 
   const isLoggedIn = !!memberLink;
   const username = isLoggedIn && memberLink


### PR DESCRIPTION
限制链接查询范围到 #Top 区域，避免误匹配其他页面链接，提高用户名提取的准确性。

- 将查询选择器从全局 'a' 标签改为 '#Top a'

- 添加 HTMLAnchorElement 类型断言